### PR TITLE
added .venv to flake8 excludes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,12 @@
 [flake8]
 exclude =
-    venv,
     .env,
+    .venv,
+    venv,
+    .git,
     .gitignore,
     README.md,
     migrations,
-    .git,
+
 max-line-length = 99
 extend-ignore = F401, E402


### PR DESCRIPTION
Added `.venv` to flake8 exceptions, because that's often the default path when you create it via IDE
Also added empty line after `exclude` and  the end of the file